### PR TITLE
Several changes:

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,8 +7,11 @@ let package = Package(
     name: "Tools4SwiftUI",
     defaultLocalization: "en",
     platforms: [
-            .macOS(.v14)      // Minimum macOS version
-        ],
+        .macOS(.v14),
+        .iOS(.v17),
+        .tvOS(.v17),
+        .visionOS(.v1)
+    ],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.
         .library(

--- a/Sources/Tools4SwiftUI/Components/SceneCommands.swift
+++ b/Sources/Tools4SwiftUI/Components/SceneCommands.swift
@@ -5,6 +5,7 @@
 //  Created by Giuseppe Rocco on 11/11/24.
 //
 
+#if os(macOS)
 import SwiftUI
 
 /// `SceneCommands` is a custom set of app commands that enhances and customizes the macOS menu bar.
@@ -20,7 +21,6 @@ import SwiftUI
 ///
 /// - Note:
 ///   - The help menu items include customizable keyboard shortcuts.
-@available(macOS 13.0, *)
 public struct SceneCommands: Commands {
     
     /// The URL of the website to be linked in the help menu.
@@ -56,22 +56,12 @@ public struct SceneCommands: Commands {
         CommandGroup(replacing: .help) {
             
             Link(destination: websiteURL) {
-                Text(
-                    verbatim: .init(
-                        localized:"action-help-readme",
-                        bundle: .module
-                    )
-                )
+                Text(Tools4SwiftUI.localized("action-help-readme"))
             }
             .keyboardShortcut("/", modifiers: [.command, .control])
             
             Link(destination: websiteURL.appendingPathComponent("privacy.html")) {
-                Text(
-                    verbatim: .init(
-                        localized:"action-help-privacy",
-                        bundle: .module
-                    )
-                )
+                Text(Tools4SwiftUI.localized("action-help-privacy"))
             }
             .keyboardShortcut("/", modifiers: [.command, .option])
         }
@@ -84,3 +74,4 @@ public struct SceneCommands: Commands {
         self.websiteURL = websiteURL
     }
 }
+#endif

--- a/Sources/Tools4SwiftUI/Extensions/View.Extension.swift
+++ b/Sources/Tools4SwiftUI/Extensions/View.Extension.swift
@@ -1,0 +1,24 @@
+//
+//  View.Extension.swift
+//  Tools4SwiftUI
+//
+//  Created by Giuseppe Rocco on 05/01/25.
+//
+
+import SwiftUI
+
+extension View {
+    
+    /// Using this method we can simply call `.bootstrapTask` as a modifier on our Views
+    /// - Parameter handler: The asynchronous closure to be executed only once
+    ///
+    /// - SeeAlso: `BootstrapTask`
+    public func bootstrapTask(
+        handler: @escaping () async throws -> Void
+    ) -> some View {
+        
+        return self.modifier(
+            BootstrapTask(handler: handler)
+        )
+    }
+}

--- a/Sources/Tools4SwiftUI/Resources/Localizable.xcstrings
+++ b/Sources/Tools4SwiftUI/Resources/Localizable.xcstrings
@@ -35,6 +35,33 @@
         }
       }
     },
+    "alert-button-dismiss" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
+        }
+      },
+      "shouldTranslate" : false
+    },
+    "alert-message-default" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "An error has occurred"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Si è verificato un errore"
+          }
+        }
+      }
+    },
     "alert-title-error" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -53,7 +80,20 @@
       }
     },
     "window-main-title" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Main window"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Finestra principale"
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/Sources/Tools4SwiftUI/Tools4SwiftUI.swift
+++ b/Sources/Tools4SwiftUI/Tools4SwiftUI.swift
@@ -6,12 +6,19 @@
 
 @_exported import SwiftUI
 
+#if os(macOS)
 import AppKit
+#endif
 
 import UniformTypeIdentifiers
 
 @MainActor public enum Tools4SwiftUI {
-        
+    
+    static func localized(_ key: String.LocalizationValue) -> String {
+        String(localized: key, bundle: .module)
+    }
+    
+    #if os(macOS)
     /// Displays an error message to the user using an `NSAlert` object.
     ///
     /// This static method provides a convenient way to present errors to the user in a UI-friendly manner
@@ -29,8 +36,10 @@ import UniformTypeIdentifiers
         
         alert.alertStyle = style
         alert.informativeText = error.localizedDescription
-        alert.messageText = String(localized: "alert-title-error", bundle: .module)
-        alert.addButton(withTitle: "OK")
+        alert.messageText = Self.localized("alert-title-error")
+        alert.addButton(
+            withTitle: Self.localized("alert-button-dismiss")
+        )
         
         if let main = NSApp.mainWindow, let key = NSApp.keyWindow {
             
@@ -78,5 +87,5 @@ import UniformTypeIdentifiers
                         
         } else { return openPanel.runModal() == .OK ? openPanel.url:nil }
     }
-    
+    #endif
 }


### PR DESCRIPTION
- Enabled multiplatform support in Package.swift starting with iOS/tvOS 17 and visionOS 1.0
- Now using preprocessor conditional statements for macOS-only definitions
- Encapsulated methods under Tools4SwiftUI in pre-processor statement for macOS
- Created new method Tools4SwiftUI.localized to retrieve module localization strings
- Provided fallback error alert mechanism for AsyncButton and BootstrapTask to also work on iOS and derivatives
- Created View.Extension.swift, adding method .bootstrapTask to directly access modifier
- Enclosed SceneCommands in macOS pre-processor statement